### PR TITLE
Use the PHP formatter date to have date in localized version

### DIFF
--- a/classes/period_stats.class.php
+++ b/classes/period_stats.class.php
@@ -162,7 +162,7 @@ class PeriodStats {
       }
     }
     if (isset($_GET['debug'])) {
-      echo "date < ".date("m Y", $this->endTimestamp)."<br/>";
+      echo "date < ".formatDate("%b %y", $this->endTimestamp)."<br/>";
       foreach ($this->statusIssueList as $state => $bugList) {
         foreach ($bugList as $bug) {
           echo "#$bug ($state)<br/>";

--- a/classes/period_stats_report.class.php
+++ b/classes/period_stats_report.class.php
@@ -123,7 +123,7 @@ class PeriodStatsReport {
 
       // Disp
       $tableLine = "<tr>\n";
-      $tableLine .= "<td class=\"right\">".date("F Y", $date)."</td>\n";
+      $tableLine .= "<td class=\"right\">".formatDate("%B %Y", $date)."</td>\n";
 
       foreach ($statusNames as $s => $sname) {
          $tableLine .= "<td class=\"right\">".$ps->statusCountList[$s]."</td>\n";

--- a/classes/time_tracking.class.php
+++ b/classes/time_tracking.class.php
@@ -553,8 +553,8 @@ class TimeTracking {
     } // foreach
 
 
-    $this->logger->debug("derive totale ($statusNames[$status]/".date("F Y", $this->startTimestamp).") = $derive");
-    $this->logger->debug("derive totale ETA($statusNames[$status]/".date("F Y", $this->startTimestamp).") = $deriveETA");
+    $this->logger->debug("derive totale ($statusNames[$status]/".formatDate("%B %Y", $this->startTimestamp).") = $derive");
+    $this->logger->debug("derive totale ETA($statusNames[$status]/".formatDate("%B %Y", $this->startTimestamp).") = $deriveETA");
 
     $this->logger->debug("Nbre Bugs en derive        : $nbDriftsPos");
     $this->logger->debug("Nbre Bugs a l'equilibre    : $nbDriftsEqual");
@@ -1089,7 +1089,7 @@ class TimeTracking {
          $submittedList[] = $row->id;
 
          if (isset($_GET['debug'])) {
-            echo "DEBUG submitted $row->id   date < ".date("m Y", $this->endTimestamp)." project $row->project_id <br/>";
+            echo "DEBUG submitted $row->id   date < ".formatDate("%b %y", $this->endTimestamp)." project $row->project_id <br/>";
          }
       }
 

--- a/graphs/graph_report.php
+++ b/graphs/graph_report.php
@@ -58,7 +58,7 @@ function displaySubmittedResolved($periodStatsReport, $width, $height) {
    $bottomLabel = array("jan", "feb", "mar", "apr");
    #$bottomLabel = array();
    #foreach ($submitted as $date => $val) {
-   #   $bottomLabel[] = date("M y", $date);
+   #   $bottomLabel[] = formatDate("%b %y", $date);
    #}
    $strBottomLabel = "bottomLabel=".implode(':', $bottomLabel);
 
@@ -83,7 +83,7 @@ function displaySubmittedResolved($periodStatsReport, $width, $height) {
    echo "</tr>\n";
    foreach ($submitted as $date => $val) {
       echo "<tr>\n";
-   	echo "<td class=\"right\">".date("F Y", $date)."</td>\n";
+   	echo "<td class=\"right\">".formatDate("%B %Y", $date)."</td>\n";
       echo "<td class=\"right\">".$val."</td>\n";
       echo "<td class=\"right\">".$resolved[$date]."</td>\n";
       echo "</tr>\n";

--- a/index.php
+++ b/index.php
@@ -109,7 +109,6 @@ function getConsistencyErrors($userid) {
             if ($sessionUser->id == $cerr->userId) {
                 $issue = IssueCache::getInstance()->getIssue($cerr->bugId);
                 $consistencyErrors[] = array('issueURL' => issueInfoURL($cerr->bugId, $issue->summary),
-                                             'date' => date("Y-m-d", $cerr->timestamp),
                                              'status' => $statusNames[$cerr->status],
                                              'desc' => $cerr->desc);
             }

--- a/reports/export_csv_weekly.php
+++ b/reports/export_csv_weekly.php
@@ -88,9 +88,9 @@ function displayTeamAndWeekSelectionForm($leadedTeamList, $teamid, $weekid, $cur
     $wDates      = week_dates($i,date('Y'));
 
     if ($i == $weekid) {
-      echo "<option selected value='".$i."'>W".$i." | ".date("d M", $wDates[1])." - ".date("d M", $wDates[5])."</option>\n";
+      echo "<option selected value='".$i."'>W".$i." | ".formatDate("%d %b", $wDates[1])." - ".formatDate("%d %b", $wDates[5])."</option>\n";
     } else {
-      echo "<option value='".$i."'>W".$i." | ".date("d M", $wDates[1])." - ".date("d M", $wDates[5])."</option>\n";
+      echo "<option value='".$i."'>W".$i." | ".formatDate("%d %b", $wDates[1])." - ".formatDate("%d %b", $wDates[5])."</option>\n";
     }
   }
   echo "</select>\n";
@@ -140,11 +140,11 @@ function exportWeekActivityReportToCSV($teamid, $weekDates, $timeTracking, $myFi
                 T_("Job").$sepChar.
                 T_("Description").$sepChar.
                 T_("Assigned to").$sepChar.
-                T_("Monday")." ".date("d/m", $weekDates[1]).$sepChar.
-                T_("Tuesday")." ".date("d/m", $weekDates[2]).$sepChar.
-                T_("Wednesday")." ".date("d/m", $weekDates[3]).$sepChar.
-                T_("Thursday")." ".date("d/m", $weekDates[4]).$sepChar.
-                T_("Friday")." ".date("d/m", $weekDates[5])."\n";
+                formatDate("%A %d/%m", $weekDates[1]).$sepChar.
+                formatDate("%A %d/%m", $weekDates[2]).$sepChar.
+                formatDate("%A %d/%m", $weekDates[3]).$sepChar.
+                formatDate("%A %d/%m", $weekDates[4]).$sepChar.
+                formatDate("%A %d/%m", $weekDates[5])."\n";
   fwrite($fh, $stringData);
 
 

--- a/reports/forecasting_report.php
+++ b/reports/forecasting_report.php
@@ -185,7 +185,7 @@ function getGraphUrl($width, $height, $legend, $bottomLabel) {
 function getDates($timeTrackingTable, $val1) {
     $i = 0;
     foreach ($timeTrackingTable as $startTimestamp => $timeTracking) {
-        $availableWorkloadGraph[date("F Y", $startTimestamp)] = round($val1[$i], 1);
+        $availableWorkloadGraph[formatDate("%B %Y", $startTimestamp)] = round($val1[$i], 1);
         $i++;
     }
     return $availableWorkloadGraph;
@@ -293,8 +293,8 @@ if (isset($_SESSION['userid'])) {
             $timeTrackingTable = createTimeTrackingList($start_day, $start_month, $start_year, $teamid);
             foreach ($timeTrackingTable as $startTimestamp => $timeTracking) {
                 $val1[] = $timeTracking->getAvailableWorkload();
-                $bottomLabel[] = date("M y", $startTimestamp);
-                #$logger->debug("workload=$workload date=".date('M y', $startTimestamp));
+                $bottomLabel[] = formatDate("%b %y", $startTimestamp);
+                #$logger->debug("workload=$workload date=".formatDate("%b %y", $startTimestamp));
             }
             $smartyHelper->assign('graphUrl', getGraphUrl(800, 300, $val1, $bottomLabel));
             $smartyHelper->assign('dates', getDates($timeTrackingTable, $val1));

--- a/reports/issue_info.php
+++ b/reports/issue_info.php
@@ -346,7 +346,7 @@ function displayTimeDrift($issue) {
   echo "<tr>\n";
   echo "  <td>".T_("DeadLine")."</td>\n";
   if (NULL != $issue->getDeadLine()) {
-      echo "  <td>".date("d M Y", $issue->getDeadLine())."</td>\n";
+      echo "  <td>".formatDate("%d %b %Y", $issue->getDeadLine())."</td>\n";
   } else {
       echo "  <td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>\n";
   }
@@ -355,7 +355,7 @@ function displayTimeDrift($issue) {
   echo "<tr>\n";
   echo "  <td>".T_("DeliveryDate")."</td>\n";
   if (NULL != $issue->deliveryDate) {
-      echo "  <td>".date("d M Y", $issue->deliveryDate)."</td>\n";
+      echo "  <td>".formatDate("%d %b %Y", $issue->deliveryDate)."</td>\n";
   } else {
       echo "  <td>&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;&nbsp;</td>\n";
   }
@@ -435,7 +435,7 @@ function displayMonth($month, $year, $issue) {
   if (0 == $found) { return; }
 
   $monthTimestamp = mktime(0, 0, 0, $month, 1, $year);
-  $monthFormated = date("F Y", $monthTimestamp);
+  $monthFormated = formatDate("%B %Y", $monthTimestamp);
   $nbDaysInMonth = date("t", $monthTimestamp);
 
   echo "<div>\n";

--- a/reports/statistics.php
+++ b/reports/statistics.php
@@ -134,7 +134,7 @@ function displaySubmittedResolved($timeTrackingTable, $width, $height) {
 
    $bottomLabel = array();
    foreach ($submittedList as $date => $val) {
-      $bottomLabel[] = date("M y", $date);
+      $bottomLabel[] = formatDate("%b %y", $date);
    }
    $strBottomLabel = "bottomLabel=".implode(':', $bottomLabel);
 
@@ -161,7 +161,7 @@ function displaySubmittedResolved($timeTrackingTable, $width, $height) {
    echo "</tr>\n";
    foreach ($submittedList as $date => $val) {
       echo "<tr>\n";
-   	echo "<td class=\"right\">".date("F Y", $date)."</td>\n";
+   	echo "<td class=\"right\">".formatDate("%B %Y", $date)."</td>\n";
       echo "<td class=\"right\">".$val."</td>\n";
       echo "<td class=\"right\">".$resolvedList[$date]."</td>\n";
       echo "</tr>\n";
@@ -191,9 +191,9 @@ function displayResolvedDriftGraph ($timeTrackingTable, $width, $height, $displa
          if ($displayNoSupport) {
             $val3[] = $driftStats_noSupport["totalDrift"] ? $driftStats_noSupport["totalDrift"] : 0;;
          }
-         $bottomLabel[] = date("M y", $startTimestamp);
+         $bottomLabel[] = formatDate("%b %y", $startTimestamp);
 
-         #echo "DEBUG: PrelEffortEstim=".$driftStats_new['totalDriftETA']." Eff=".$driftStats_new['totalDrift']." date=".date('M y', $startTimestamp)."<br/>\n";
+         #echo "DEBUG: PrelEffortEstim=".$driftStats_new['totalDriftETA']." Eff=".$driftStats_new['totalDrift']." date=".formatDate("%b %y", $startTimestamp)."<br/>\n";
    }
    $graph_title="title=".("Effort Deviation");
    $graph_width="width=$width";
@@ -238,7 +238,7 @@ function displayResolvedDriftGraph ($timeTrackingTable, $width, $height, $displa
    $i = 0;
    foreach ($timeTrackingTable as $startTimestamp => $timeTracking) {
       echo "<tr>\n";
-      echo "<td class=\"right\">".date("F Y", $startTimestamp)."</td>\n";
+      echo "<td class=\"right\">".formatDate("%B %Y", $startTimestamp)."</td>\n";
       echo "<td class=\"right\">".round($val1[$i],2)."</td>\n";
       echo "<td class=\"right\">".round($val2[$i],2)."</td>\n";
       if ($displayNoSupport) {
@@ -270,9 +270,9 @@ function displayDevelopersWorkloadGraph ($timeTrackingTable, $width, $height) {
 
          $workload = $timeTracking->getAvailableWorkload();
          $val1[] = $workload;
-         $bottomLabel[] = date("M y", $startTimestamp);
+         $bottomLabel[] = formatDate("%b %y", $startTimestamp);
 
-         #$logger->debug("workload=$workload date=".date('M y', $startTimestamp));
+         #$logger->debug("workload=$workload date=".formatDate("%b %y", $startTimestamp));
    }
    $graph_title="title=".("Developers Workload");
    $graph_width="width=$width";
@@ -304,7 +304,7 @@ function displayDevelopersWorkloadGraph ($timeTrackingTable, $width, $height) {
    $i = 0;
    foreach ($timeTrackingTable as $startTimestamp => $timeTracking) {
       echo "<tr>\n";
-      echo "<td class=\"right\">".date("F Y", $startTimestamp)."</td>\n";
+      echo "<td class=\"right\">".formatDate("%B %Y", $startTimestamp)."</td>\n";
       echo "<td class=\"right\">".round($val1[$i], 1)."</td>\n";
       echo "</tr>\n";
       $i++;
@@ -337,10 +337,10 @@ function displayTimeDriftGraph ($timeTrackingTable, $width, $height) {
          $nbTasks = $timeDriftStats["nbDriftsNeg"] + $timeDriftStats["nbDriftsPos"];
          $val1[] = (0 != $nbTasks) ? $timeDriftStats["nbDriftsNeg"] * 100 / $nbTasks : 100;
 
-         $bottomLabel[] = date("M y", $startTimestamp);
+         $bottomLabel[] = formatDate("%b %y", $startTimestamp);
 
-         #echo "DEBUG: nbDriftsNeg=".$timeDriftStats['nbDriftsNeg']." nbDriftsPos=".$timeDriftStats['nbDriftsPos']." date=".date('M y', $startTimestamp)."<br/>\n";
-         #echo "DEBUG: driftNeg=".$timeDriftStats['driftNeg']." driftPos=".$timeDriftStats['driftPos']." date=".date('M y', $startTimestamp)."<br/>\n";
+         #echo "DEBUG: nbDriftsNeg=".$timeDriftStats['nbDriftsNeg']." nbDriftsPos=".$timeDriftStats['nbDriftsPos']." date=".formatDate("%b %y", $startTimestamp)."<br/>\n";
+         #echo "DEBUG: driftNeg=".$timeDriftStats['driftNeg']." driftPos=".$timeDriftStats['driftPos']." date=".formatDate("%b %y", $startTimestamp)."<br/>\n";
    }
    $graph_title="title=".("Adherence to deadlines");
    $graph_width="width=$width";
@@ -372,7 +372,7 @@ function displayTimeDriftGraph ($timeTrackingTable, $width, $height) {
    $i = 0;
    foreach ($timeTrackingTable as $startTimestamp => $timeTracking) {
       echo "<tr>\n";
-      echo "<td class=\"right\">".date("F Y", $startTimestamp)."</td>\n";
+      echo "<td class=\"right\">".formatDate("%B %Y", $startTimestamp)."</td>\n";
       echo "<td class=\"right\">".round($val1[$i], 1)."%</td>\n";
       echo "</tr>\n";
       $i++;
@@ -395,7 +395,7 @@ function displayEfficiencyGraph ($timeTrackingTable, $width, $height) {
 
          $val1[] = $timeTracking->getEfficiencyRate();
          $val2[] = $timeTracking->getSystemDisponibilityRate();
-         $bottomLabel[] = date("M y", $startTimestamp);
+         $bottomLabel[] = formatDate("%b %y", $startTimestamp);
    }
    $graph_title="title=".("Efficiency");
    $graph_width="width=$width";
@@ -428,7 +428,7 @@ function displayEfficiencyGraph ($timeTrackingTable, $width, $height) {
    $i = 0;
    foreach ($timeTrackingTable as $startTimestamp => $timeTracking) {
       echo "<tr>\n";
-      echo "<td class=\"right\">".date("F Y", $startTimestamp)."</td>\n";
+      echo "<td class=\"right\">".formatDate("%B %Y", $startTimestamp)."</td>\n";
       echo "<td class=\"right\">".round($val1[$i], 2)."%</td>\n";
       echo "<td class=\"right\">".round($val2[$i], 3)."%</td>\n";
       echo "</tr>\n";
@@ -464,7 +464,7 @@ function createTimeTrackingList($start_day, $start_month, $start_year, $teamid) 
          $timeTracking = new TimeTracking($startTimestamp, $endTimestamp, $teamid);
          $timeTrackingTable[$startTimestamp] = $timeTracking;
 
-         #echo "DEBUG: ETA=".$driftStats_new['totalDriftETA']." Eff=".$driftStats_new['totalDrift']." date=".date('M y', $startTimestamp)."<br/>\n";
+         #echo "DEBUG: ETA=".$driftStats_new['totalDriftETA']." Eff=".$driftStats_new['totalDrift']." date=".formatDate("%b %y", $startTimestamp)."<br/>\n";
          $day   = 1;
       }
       $start_month = 1;
@@ -491,10 +491,10 @@ function displayReopenedRateGraph ($timeTrackingTable, $width, $height) {
          $val1[] = $reopenedRate;
          $val2[] = $nbReopened;
 
-         $bottomLabel[] = date("M y", $startTimestamp);
+         $bottomLabel[] = formatDate("%b %y", $startTimestamp);
 
-         #echo "DEBUG: nbDriftsNeg=".$timeDriftStats['nbDriftsNeg']." nbDriftsPos=".$timeDriftStats['nbDriftsPos']." date=".date('M y', $startTimestamp)."<br/>\n";
-         #echo "DEBUG: driftNeg=".$timeDriftStats['driftNeg']." driftPos=".$timeDriftStats['driftPos']." date=".date('M y', $startTimestamp)."<br/>\n";
+         #echo "DEBUG: nbDriftsNeg=".$timeDriftStats['nbDriftsNeg']." nbDriftsPos=".$timeDriftStats['nbDriftsPos']." date=".formatDate("%b %y", $startTimestamp)."<br/>\n";
+         #echo "DEBUG: driftNeg=".$timeDriftStats['driftNeg']." driftPos=".$timeDriftStats['driftPos']." date=".formatDate("%b %y", $startTimestamp)."<br/>\n";
    }
    $graph_title="title=".("Reopened Rate");
    $graph_width="width=$width";
@@ -527,7 +527,7 @@ function displayReopenedRateGraph ($timeTrackingTable, $width, $height) {
    $i = 0;
    foreach ($timeTrackingTable as $startTimestamp => $timeTracking) {
       echo "<tr>\n";
-      echo "<td class=\"right\">".date("F Y", $startTimestamp)."</td>\n";
+      echo "<td class=\"right\">".formatDate("%B %Y", $startTimestamp)."</td>\n";
       echo "<td class=\"right\">".round($val1[$i], 1)."%</td>\n";
       echo "<td class=\"right\">".$val2[$i]."</td>\n";
       echo "</tr>\n";

--- a/timetracking/holidays_report.php
+++ b/timetracking/holidays_report.php
@@ -118,7 +118,7 @@ function displayHolidaysMonth($month, $year, $teamid, $isExternalTasks = false) 
   $pink  ="FF699D";
 
   $monthTimestamp = mktime(0, 0, 0, $month, 1, $year);
-  $monthFormated = date("F Y", $monthTimestamp);
+  $monthFormated = formatDate("%B %Y", $monthTimestamp);
   $nbDaysInMonth = date("t", $monthTimestamp);
 
   $today = date("d-m-Y");

--- a/timetracking/team_activity_report.php
+++ b/timetracking/team_activity_report.php
@@ -129,9 +129,9 @@ function displayTeamAndWeekSelectionForm($leadedTeamList, $teamid, $weekid, $cur
     $wDates      = week_dates($i,$curYear);
 
     if ($i == $weekid) {
-      echo "<option selected value='".$i."'>W".$i." | ".date("d M", $wDates[1])." - ".date("d M", $wDates[5])."</option>\n";
+      echo "<option selected value='".$i."'>W".$i." | ".formatDate("%d %b", $wDates[1])." - ".formatDate("%d %b", $wDates[5])."</option>\n";
     } else {
-      echo "<option value='".$i."'>W".$i." | ".date("d M", $wDates[1])." - ".date("d M", $wDates[5])."</option>\n";
+      echo "<option value='".$i."'>W".$i." | ".formatDate("%d %b", $wDates[1])." - ".formatDate("%d %b", $wDates[5])."</option>\n";
     }
   }
   echo "</select>\n";
@@ -229,13 +229,13 @@ function displayWeekDetails($weekid, $weekDates, $userid, $timeTracking, $realna
   echo "<th width='7%'>".T_("Project")."</th>\n";
   echo "<th width='5' title='".T_("Target version")."'>".T_("Target")."</th>\n";
   echo "<th width='10%'>".T_("Job")."</th>\n";
-  echo "<th width='10'>".T_("Monday")."<br>".date("d M", $weekDates[1])."</th>\n";
-  echo "<th width='10'>".T_("Tuesday")."<br/>".date("d M", $weekDates[2])."</th>\n";
-  echo "<th width='10'>".T_("Wednesday")."<br/>".date("d M", $weekDates[3])."</th>\n";
-  echo "<th width='10'>".T_("Thursday")."<br/>".date("d M", $weekDates[4])."</th>\n";
-  echo "<th width='10'>".T_("Friday")."<br/>".date("d M", $weekDates[5])."</th>\n";
-  echo "<th width='10' style='background-color: #D8D8D8;' >".T_("Saturday")."<br/>".date("d M", $weekDates[6])."</th>\n";
-  echo "<th width='10' style='background-color: #D8D8D8;' >".T_("Sunday")."<br/>".date("d M", $weekDates[7])."</th>\n";
+  echo "<th width='10'>".formatDate("%A %d %b", $weekDates[1])."</th>\n";
+  echo "<th width='10'>".formatDate("%A %d %b", $weekDates[2])."</th>\n";
+  echo "<th width='10'>".formatDate("%A %d %b", $weekDates[3])."</th>\n";
+  echo "<th width='10'>".formatDate("%A %d %b", $weekDates[4])."</th>\n";
+  echo "<th width='10'>".formatDate("%A %d %b", $weekDates[5])."</th>\n";
+  echo "<th width='10' style='background-color: #D8D8D8;' >".formatDate("%A %d %b", $weekDates[6])."</th>\n";
+  echo "<th width='10' style='background-color: #D8D8D8;' >".formatDate("%A %d %b", $weekDates[7])."</th>\n";
   echo "</tr>\n";
   foreach ($weekTracks as $bugid => $jobList) {
     $issue = IssueCache::getInstance()->getIssue($bugid);
@@ -300,13 +300,13 @@ function displayWeek($weekid, $weekDates, $userid, $timeTracking, $realname, $wo
   echo "<th width='1%'>".T_("Progress")."</th>\n";
   echo "<th width='7%'>".T_("Project")."</th>\n";
   echo "<th width='5' title='".T_("Target version")."'>".T_("Target")."</th>\n";
-  echo "<th width='10'>".T_("Monday")."<br>".date("d M", $weekDates[1])."</th>\n";
-  echo "<th width='10'>".T_("Tuesday")."<br/>".date("d M", $weekDates[2])."</th>\n";
-  echo "<th width='10'>".T_("Wednesday")."<br/>".date("d M", $weekDates[3])."</th>\n";
-  echo "<th width='10'>".T_("Thursday")."<br/>".date("d M", $weekDates[4])."</th>\n";
-  echo "<th width='10'>".T_("Friday")."<br/>".date("d M", $weekDates[5])."</th>\n";
-  echo "<th width='10' style='background-color: #D8D8D8;' >".T_("Saturday")."<br/>".date("d M", $weekDates[6])."</th>\n";
-  echo "<th width='10' style='background-color: #D8D8D8;' >".T_("Sunday")."<br/>".date("d M", $weekDates[7])."</th>\n";
+  echo "<th width='10'>".formatDate("%A %d %b", $weekDates[1])."</th>\n";
+  echo "<th width='10'>".formatDate("%A %d %b", $weekDates[2])."</th>\n";
+  echo "<th width='10'>".formatDate("%A %d %b", $weekDates[3])."</th>\n";
+  echo "<th width='10'>".formatDate("%A %d %b", $weekDates[4])."</th>\n";
+  echo "<th width='10'>".formatDate("%A %d %b", $weekDates[5])."</th>\n";
+  echo "<th width='10' style='background-color: #D8D8D8;' >".formatDate("%A %d %b", $weekDates[6])."</th>\n";
+  echo "<th width='10' style='background-color: #D8D8D8;' >".formatDate("%A %d %b", $weekDates[7])."</th>\n";
   echo "</tr>\n";
   foreach ($weekTracks as $bugid => $jobList) {
     $issue = IssueCache::getInstance()->getIssue($bugid);

--- a/tools.php
+++ b/tools.php
@@ -249,9 +249,17 @@ function dayofyear2timestamp( $tDay, $year) {
    return( $timestamp );
 }
 
-// ---------------------------
 /**
- *
+ * Format the date in locale
+ * @param string $pattern The pattern to user
+ * @param int $timestamp The timestamp to format
+ * @return string The localized date
+ */
+function formatDate($pattern, $timestamp) {
+   return utf8_encode(ucwords(strftime($pattern, $timestamp)));
+}
+
+/**
  * explode string to 2-dimentionnal array
  *
  * Usage:


### PR DESCRIPTION
New method in tools.php - formatDate($pattern,$timestamp) to replace date($pattern,$timestamp) only when date is used for get formatted date.

For example :
date('M y',$timestamp) => formatDate("%b %y",$timestamp)
date("F Y",$timestamp) => formatDate("%B %Y",$timestamp)
date("d M",$timestamp) => formatDate("%d %b",$timestamp)

Read more :
http://www.php.net/manual/fr/function.strftime.php
http://www.php.net/manual/fr/function.date.php
