### PR TITLE
FIX Remove useless import.

### DIFF
--- a/classes/time_tracking.class.php
+++ b/classes/time_tracking.class.php
@@ -16,7 +16,6 @@
     along with CoDev-Timetracking.  If not, see <http://www.gnu.org/licenses/>.
 */
 
-require_once '../path.inc.php';
 require_once('Logger.php');
 
 require_once "constants.php";


### PR DESCRIPTION
Time tracking class can be only use by "include"
so path file will be always already include in the caller page
