### PR TITLE
Parse .htaccess files in order to override httpd.conf. 

### DIFF
--- a/doc/docker/Dockerfile
+++ b/doc/docker/Dockerfile
@@ -122,7 +122,6 @@ RUN ln -s /usr/share/phpMyAdmin/ /var/www/phpmyadmin && \
 RUN sed -i "s/Require ip 127.0.0.1/Require ip 172.17/" /etc/httpd/conf.d/phpMyAdmin.conf && \
     sed -i "s/Allow from 127.0.0.1/Allow from 172.17/" /etc/httpd/conf.d/phpMyAdmin.conf
 
-
 # ------------------
 # install MantisBT
 
@@ -160,6 +159,22 @@ RUN set -xe \
     && ln -s /var/www/html/codevtt/mantis_plugin/mantis_2_0/CodevTT \
     && mkdir -p /tmp/codevtt/logs \
     && chown -R apache:apache /tmp/codevtt
+
+# Update httpd.conf in order to restrict access as defined by .htaccess file.
+# .htaccess files are not evaluated since a default apache install does not allow to override directives in /var/www
+RUN set -xe \
+    && echo "#Mantis specific access policy" > /etc/httpd/conf.d/mantis.conf \
+    && echo "#CodevTT specific access policy" > /etc/httpd/conf.d/codevtt.conf \
+    && for f in $(find /var/www/html/mantis -name .htaccess) ; do \
+    echo "<Directory $(dirname $f)>" >> /etc/httpd/conf.d/mantis.conf \
+    && cat $f >> /etc/httpd/conf.d/mantis.conf \
+    && echo -e "\n</Directory>\n" >> /etc/httpd/conf.d/mantis.conf \
+    ; done \
+    && for f in $(find /var/www/html/codevtt -name .htaccess) ; do \
+    echo "<Directory $(dirname $f)>" >> /etc/httpd/conf.d/codevtt.conf \
+    && cat $f >> /etc/httpd/conf.d/codevtt.conf \
+    && echo -e "\n</Directory>\n" >> /etc/httpd/conf.d/codevtt.conf \
+    ; done
 
 # ------------------
 # Adding config files (bugtracker)


### PR DESCRIPTION
There is a major security issue in the codevtt docker container.
A user with no privilege can reach any config file in the container by using a web browser and requesting apache to serve the files.
On an Apache httpd  fresh installation, the directive "AllowOverride" is set to "None" in the /var/www folder. It seems to load website faster, and since the owner of this directory is the apache user it prevents an attacker to rewrite existing .htaccess by exploiting other feature.

According to this points:  The Dockerfile will parse a fresh install of mantis and codevtt in order to generate httpd/conf.d/mantis.conf and httpd/conf.d/codevtt.conf files. This way all htaccess rules set in both project are automatically set safely in the container.